### PR TITLE
Add workflow to validate with sushi and ig publisher

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -1,0 +1,42 @@
+name: Validate docs
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [opened, synchronize] # This will trigger the workflow only when a PR is opened or updated with new commits
+
+jobs:
+  sushi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Validate with Sushi
+        run: sushi .
+
+  ig-publisher:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Jekyll
+        run: sudo gem install jekyll
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Install IG publisher
+        run: |
+          chmod +x ./_updatePublisher.sh
+          ./_updatePublisher.sh -y
+
+      - name: Validate IG
+        run: |
+          chmod +x ./_genonce.sh
+          ./_genonce.sh

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Install IG publisher
         run: |
+          curl -L https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main/_updatePublisher.sh -o ./_updatePublisher.sh
           chmod +x ./_updatePublisher.sh
           ./_updatePublisher.sh -y
 


### PR DESCRIPTION
Added validation to PRs and any commits to the `master` branch to ensure that only content that builds an IG successfully makes it in. This will help ensure that this IG doesn't get any broken builds.

Any QA errors or warnings will still be allowed though, and [manual approval](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks) is necessary for it to run from forks on the first time.

Example of it working in [fhircast-docs](https://github.com/HL7/fhircast-docs/pull/578):

![image](https://github.com/HL7/fhir-ips/assets/110988/e19cbb21-8812-48ef-803e-61e14bbfc2f4)

Let me know if there are any questions about this improvement! :slightly_smiling_face: 